### PR TITLE
Wrong readable count format returned

### DIFF
--- a/src/Traits/CanBeViewed.php
+++ b/src/Traits/CanBeViewed.php
@@ -67,6 +67,6 @@ trait CanBeViewed
 
     public function getViewersCountReadableAttribute()
     {
-        return $this->viewersCount();
+        return $this->viewersCountReadable();
     }
 }


### PR DESCRIPTION
Accessor method `getViewersCountReadableAttribute()` or  `viewers_count_readable_attribute` does not return a readable format it returns data same as or `getViewersCountAttribute()` `viewers_count ` attribute.